### PR TITLE
Fix local path issue for recent (6.0 and higher) nodejs versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "grunt-contrib-watch": "^0.6.1",
     "grunt-mocha-cli": "^1.9.0",
     "load-grunt-tasks": "^0.6.0",
-    "should": "^4.0.4"
+    "should": "4.0.4"
   },
   "keywords": [
     "least-privilege",

--- a/src/module.litcoffee
+++ b/src/module.litcoffee
@@ -10,7 +10,10 @@
             @fileName = @modModule._findPath @libName, @modulePaths
             @requestLib = @fileName || @libName
             @builtIn = @requestLib.indexOf(".js") == -1
-            @pathName = path.dirname @fileName
+            if @fileName != false
+                @pathName = path.dirname @fileName
+            else
+                @pathName = ""
 
         load: (requireFunc = @membranedRequire) ->
             throw new Error "`require` must be a function" if typeof requireFunc != "function"


### PR DESCRIPTION
In recent versions of nodeJS, path.dirname does not accept "false" as input, but throws an error. Also, the tests need an old version of "should" to run.